### PR TITLE
Big endian support

### DIFF
--- a/aes.c
+++ b/aes.c
@@ -154,7 +154,7 @@
             w=(w&-256) | S(w&255),w=R(w,8);
           } 
           // AddConstant, update constant
-          if(!r)w=R(w,8)^c,c=M(c);
+          if(!r)w=R(w,8)^(c<<SHF_C),c=M(c);
           // AddRoundKey, 2nd part of ExpandKey
           for(i=0;i<4;i++) {
             ((u32*)s)[i]=x[i]^k[r*4+i], w=k[r*4+i]^=w;
@@ -189,7 +189,7 @@
             w=(w&-256)|S(w&255), w=R(w,8);
           }
           // AddConstant, AddRoundKey, 2nd part of ExpandKey
-          w=R(w, 8)^c;
+          w=R(w, 8)^(c<<SHF_C);
           for(i=0;i<4;i++) {
             ((u32*)s)[i]=x[i]^k[i], w=k[i]^=w;
           }

--- a/aes.h
+++ b/aes.h
@@ -39,13 +39,27 @@
 #error "AES-256 is not supported by the assembly code."
 #endif
 
+#ifndef AES_BIG_ENDIAN
+  #if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    #define AES_BIG_ENDIAN 1
+  #elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    #define AES_BIG_ENDIAN 0
+  #endif
+#endif
+
 typedef unsigned char u8;
 typedef char s8;
 
 #if AES_INT_LEN == 1
   typedef unsigned char u32;
 #else
-  #define R(v,n)(((v)>>(n))|((v)<<(32-(n))))
+  #if AES_BIG_ENDIAN
+    #define R(v,n)(((v)<<(n))|((v)>>(32-(n))))
+    #define SHF_C 24
+  #else
+    #define R(v,n)(((v)>>(n))|((v)<<(32-(n))))
+    #define SHF_C 0
+  #endif
   typedef unsigned int u32;
 #endif
 


### PR DESCRIPTION
I needed a tiny AES implementation for some PowerPC shellcode. Unfortunately, big endian code produced the wrong output. This minor changes should fix it, though my testing has been limited to powerpc gcc + powerpc qemu.

Feel free to reimplement these changes however you see fit.